### PR TITLE
Fix cpp/c++ link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 - [Programming](#programming)
   - [Python](#python)
   - [Matlab](#matlab)
-  - [C++](#c++)
+  - [C++](#c)
   - [JavaScript](#javascript)
 - [Resources](#resources)
   - [Ebooks](#ebooks)


### PR DESCRIPTION
The cpp/c++ link was linked to `c++`, but the `c++` header gets the id `c`.