### PR TITLE
Add BindsNET (Python package for simulating SNNs)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,8 @@ Software, libraries and frameworks for development purposes.
 - [NuPic](https://github.com/numenta/nupic) - Numenta Platform for Intelligent Computing is an implementation of Hierarchical Temporal Memory (HTM), a theory of intelligence based strictly on the neuroscience of the neocortex.
 - [Brian2](https://github.com/brian-team/brian2) - Free, open source simulator for spiking neural networks.
 - [expyriment](https://github.com/expyriment/expyriment) - Platform-independent lightweight Python library for designing and conducting timing-critical behavioural and neuroimaging experiments.
-
+ - [BindsNET](https://github.com/Hananel-Hazan/bindsnet) - Package for simulating spiking neural networks for reinforcement & machine learning.
+ 
 ### Matlab
 
 - [FieldTrip](https://github.com/fieldtrip/fieldtrip) - Toolbox for MEG and EEG analysis.


### PR DESCRIPTION
This PR adds the BindsNET Python package that be used for simulating spiking neural networks (SNNs) for machine & reinforcement learning problems. 

Main paper: https://www.frontiersin.org/articles/10.3389/fninf.2018.00089/full
Repo: https://github.com/Hananel-Hazan/bindsnet