### PR TITLE
Add NeuroElectro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ MOOCs may be patterned on a college or university course or may be less structur
 - [McCulloch & Pitts Neural Net Simulator](https://justinmeiners.github.io/neural-nets-sim/) - Simulator for a historical computational model based on neurons.
 - [ModelDB](https://senselab.med.yale.edu/ModelDB/default.cshtml) - Searchable database for computational neuroscience models.
 - [NeuronDB](https://senselab.med.yale.edu/NeuronDB) - Searchable database for  of three types of neuronal properties: voltage gated conductances, neurotransmitter receptors, and neurotransmitter substances.
+- [NeuroElectro](https://neuroelectro.org/) - Searchable database of neurons and their electrophysiological properties (extracted from literature)
 - [Neuroscience Mindmap](https://learn-anything.xyz/neuroscience) - Interactive mindmap containing curated resources for anyone interested in learning neuroscience.
 - [neuroSummerSchools](https://github.com/PhABC/neuroSummerSchools) - List of summer (and seasonal) summer schools in neuroscience and related fields.
 - [Brain Matters](https://brainpodcast.com/) - Neuroscience podcast where real neuroscientists sit down and talk about the brain.


### PR DESCRIPTION
Adds NeuroElectro

This site is similar to NeuronDB or ModelDB but for neurons & their electrophysiological properties (e.g. resting membrane potential, time constant, spontaneous firing rate). This data was aggregated using semi-automated text mining of existing literature from 1984 to 2016.

They provide an API and easily explorable website e.g. https://neuroelectro.org/neuron/111/