### PR TITLE
Added neuroimaging@python.org to communities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,7 @@ MOOCs may be patterned on a college or university course or may be less structur
 - [Quora](https://www.quora.com/topic/Neuroscience-1) - Neuroscience topic on Quora contains answers, often by experts, to questions ranging from basic to advanced.
 - [Reddit](https://www.reddit.com/r/ScienceNetwork/comments/ptye0/link_tables/) - List of neuroscience, psychology and cognitive science subreddits.
 - [StackExchange](https://psychology.stackexchange.com) - Psychology and neuroscience StackExchange site.
+- [neuroimaging@python.org](https://mail.python.org/mailman/listinfo/neuroimaging) - A list for discussion of neuroimaging analysis in Python. Among other things, this list is home to discussions concerning [NiPy](https://nipy.org/) projects (including NiBabel, Nilearn, dipy, MNE-Python, and more).
 
 ### Newsletters
 - [On The Brain](http://neuro.hms.harvard.edu/harvard-mahoney-neuroscience-institute/hmni-newsletter) - Harvard Mahoney Neuroscience Institute's quarterly e-newsletter.


### PR DESCRIPTION
The community itself is NiPy, and neuroimaging@python.org is, in fact, the mailing list, but it seemed like the most appropriate place.