### PR TITLE
Add DeepLabCut to Python section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,8 @@ Software, libraries and frameworks for development purposes.
  - [BindsNET](https://github.com/Hananel-Hazan/bindsnet) - Package for simulating spiking neural networks for reinforcement & machine learning.
  - [SpikeInterface](https://github.com/SpikeInterface/spikeinterface) - Framework designed to unify spike-sorting technologies
  - [NiMARE](https://nimare.readthedocs.io/en/latest/) - NiMARE is a Python package for neuroimaging meta-analyses
- 
+ - [DeepLabCut](https://github.com/DeepLabCut/DeepLabCut) - Markerless pose estimation for behavior research using transfer learning, widely used in neuroscience labs for tracking movement kinematics across species.
+
 ### Matlab
 
 - [Brain Dynamics Toolbox](https://bdtoolbox.org/) - Open software for simulating dynamical systems in neuroscience.


### PR DESCRIPTION
Adds [DeepLabCut](https://github.com/DeepLabCut/DeepLabCut) to the Python section.

DeepLabCut is a widely adopted Python package for markerless pose estimation, built on transfer learning from ImageNet-pretrained networks. It is standard tooling in computational neuroscience labs for quantifying behavioral kinematics — tracking body part trajectories across video frames without physical markers. The package has 5,500+ GitHub stars and active development (last commit Feb 2026).

It fits the existing Python section alongside SpikeInterface and other data-acquisition/analysis tools.