### PR TITLE
Add suite2p to Python section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,8 @@ Software, libraries and frameworks for development purposes.
  - [BindsNET](https://github.com/Hananel-Hazan/bindsnet) - Package for simulating spiking neural networks for reinforcement & machine learning.
  - [SpikeInterface](https://github.com/SpikeInterface/spikeinterface) - Framework designed to unify spike-sorting technologies
  - [NiMARE](https://nimare.readthedocs.io/en/latest/) - NiMARE is a Python package for neuroimaging meta-analyses
- 
+ - [suite2p](https://github.com/MouseLand/suite2p) - Fast, accurate calcium imaging pipeline for cell detection, signal extraction, and spike deconvolution from two-photon microscopy data.
+
 ### Matlab
 
 - [Brain Dynamics Toolbox](https://bdtoolbox.org/) - Open software for simulating dynamical systems in neuroscience.


### PR DESCRIPTION
Adds [suite2p](https://github.com/MouseLand/suite2p) to the Python section.

suite2p is a fast, scalable Python pipeline for processing two-photon calcium imaging data — performing cell detection (ROI extraction), neuropil correction, signal extraction, and spike deconvolution. Developed at the MouseLand lab (Janelia/UCL), it is one of the most widely used tools in systems neuroscience for analyzing neural population activity from fluorescence imaging. It has 431+ GitHub stars and active development (last commit March 2026).

It fills a genuine gap in the Python section, which currently covers electrophysiology tooling (SpikeInterface) but not calcium imaging analysis.