### PR TITLE
Add EEGauge (EEG/BCI dataset-cards tool) to Programming > Python

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Software, libraries and frameworks for development purposes.
 - [AllenSDK](https://github.com/AllenInstitute/AllenSDK) - Toolkit for accessing and processing data from the Allen Institute for Brain Science, including the Allen Brain Atlas and Allen Brain Observatory.
 - [Suite2p](https://github.com/MouseLand/suite2p) - Pipeline for cell detection and signal extraction from large-scale two-photon calcium imaging recordings.
 - [Neo](https://github.com/NeuralEnsemble/python-neo) - Package for representing electrophysiology data in Python, with readers for a wide range of neurophysiology file formats.
+- [EEGauge](https://github.com/YG-paaleee/eegauge) - Generates honest "dataset cards" for public EEG/BCI datasets: leakage-aware baselines, chance level and significance, per-class metrics, and metadata from MOABB and EEGDash.
  
 ### Matlab
 


### PR DESCRIPTION
Adds **EEGauge** to Programming > Python (at the bottom of the category, per the contribution guidelines).

Disclosure: I'm the author. EEGauge is a small, MIT-licensed Python CLI that generates plain-language "dataset cards" for public EEG/BCI datasets - it runs a simple CSP+LDA baseline, reports the chance level and an approximate significance test, shows per-class metrics and a confusion matrix, and flags data-leakage risks (within- vs cross-subject). It builds on MNE-Python (already listed here) and reads metadata from MOABB and EEGDash (OpenNeuro/NEMAR). Not medical software.

- Repo: https://github.com/YG-paaleee/eegauge
- Actively maintained: tagged releases, CI on Windows/Linux x Python 3.11/3.12, tests, docs.

Happy to adjust the wording or placement if you'd prefer. Thanks for maintaining the list!
