### PR TITLE
Add Monty to python frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Software, libraries and frameworks for development purposes.
 - [AllenSDK](https://github.com/AllenInstitute/AllenSDK) - Toolkit for accessing and processing data from the Allen Institute for Brain Science, including the Allen Brain Atlas and Allen Brain Observatory.
 - [Suite2p](https://github.com/MouseLand/suite2p) - Pipeline for cell detection and signal extraction from large-scale two-photon calcium imaging recordings.
 - [Neo](https://github.com/NeuralEnsemble/python-neo) - Package for representing electrophysiology data in Python, with readers for a wide range of neurophysiology file formats.
+- [Monty](https://github.com/thousandbrainsproject/tbp.monty) - a sensorimotor learning framework based on the thousand brains theory of the neocortex.
  
 ### Matlab
 


### PR DESCRIPTION
Hi, adding [Monty](https://github.com/thousandbrainsproject/tbp.monty) to the python frameworks. The repo is well-linked. There's also a [Discourse](https://forum.thousandbrains.org/) to it, and [docs](https://docs.thousandbrains.org/)